### PR TITLE
allows this script to be used in a testing framework. 

### DIFF
--- a/_spaun/modules/motor/data.py
+++ b/_spaun/modules/motor/data.py
@@ -6,7 +6,7 @@ from ..._networks import convert_func_2_diff_func
 
 class MotorDataObject(object):
     def __init__(self):
-        self.filepath = os.path.join('_spaun', 'modules', 'motor')
+        self.filepath = os.path.dirname(__file__)
 
         canonical_paths = np.load(os.path.join(self.filepath,
                                                'canon_paths.npz'))

--- a/_spaun/modules/vision/data.py
+++ b/_spaun/modules/vision/data.py
@@ -10,7 +10,7 @@ from .utils import load_image_data
 
 class VisionDataObject(object):
     def __init__(self):
-        self.filepath = os.path.join('_spaun', 'modules', 'vision')
+        self.filepath = os.path.dirname(__file__)
 
         # --- LIF vision network configurations ---
         self.max_rate = 63.04


### PR DESCRIPTION
this pr allows a unit test suite to utilise this script to generate the spaun network, but without going though a simulator. This in itself then allows the testing suite to test its conversion from the nengo graph, into the backend graph. 

It also includes a few file path fixes, where it returns absolute paths, instead of relative paths, so that it can be called from the test suite. I have not gone through the entire codebase looking for other places where other relative paths are used. But these one were essential for testing my tools. 

I note that there's some paths in this codebase that look like they assume a given computers file format. (one for handling mpi components for example). I have not touched these. 